### PR TITLE
Add a support for building RT PREEMPT kernel version

### DIFF
--- a/config-fedberry-rt.cfg
+++ b/config-fedberry-rt.cfg
@@ -1,0 +1,44 @@
+###
+# Planet CCRMA low latency kernel options
+###
+
+CONFIG_IRQ_FORCED_THREADING=y
+
+# do not add debugging options
+# CONFIG_DEBUG_PREEMPT is not set
+# CONFIG_PREEMPT_TRACER is not set
+
+# enable rt preemption
+CONFIG_PREEMPT_RT_BASE=y
+CONFIG_PREEMPT_RT_FULL=y
+
+# "Testing module to detect hardware induced latencies"
+CONFIG_HWLAT_DETECTOR=m
+
+# enable histograms for now
+
+# "Interrupts-off Latency Histogram"
+CONFIG_INTERRUPT_OFF_HIST=y
+
+# "Preemption-off Latency Histogram"
+CONFIG_PREEMPT_OFF_HIST=y
+
+# "Scheduling Latency Histogram"
+CONFIG_WAKEUP_LATENCY_HIST=y
+
+# "Missed Timer Offsets Histogram"
+CONFIG_MISSED_TIMER_OFFSETS_HIST=y
+
+# taken from old rt configurations for 2.6.33
+CONFIG_RCU_BOOST=y
+# we also need these (just taking the defaults for now):
+CONFIG_RCU_BOOST_PRIO=1
+CONFIG_RCU_BOOST_DELAY=500
+
+# CONFIG_DEBUG_SLAB is not set
+# CONFIG_RCU_CPU_STALL_VERBOSE is not set
+
+# disable uprobes which is not compatible with the rt patch
+# (before 3.8 this was done by disabling the uprobes patch)
+# CONFIG_UPROBE_EVENT is not set
+# CONFIG_UPROBE is not set


### PR DESCRIPTION
By default it's disabled and can be enabled either using rpmbuild
--with rt_preempt option or by changing defaults in .spec file.